### PR TITLE
Update fieldtype checking to allow compatibility with PW 3

### DIFF
--- a/ProcessDateArchiver.module
+++ b/ProcessDateArchiver.module
@@ -424,11 +424,8 @@ class ProcessDateArchiver extends Process implements Module {
 		$field->addOption('');
 
 		foreach ($this->fields as $inputField) {
-			foreach ($this->fieldtypes as $fieldtype) {
-				if ($inputField->type instanceof $fieldtype) {
-					$field->addOption($inputField->id, $inputField->name);
-					break;
-				}
+			if (in_array($inputField->type, $this->fieldtypes)) {
+				$field->addOption($inputField->id, $inputField->name);
 			}
 		}
 


### PR DESCRIPTION
The previous "instanceof $fieldtype" would fail due to namespace format of the string being checked. New code uses Inputfield "type" property - which is the classname as a string.
